### PR TITLE
hotfix: fixed status code metrics, wont only RPS metrics

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -3,11 +3,16 @@ import app.main as main
 import logging
 from fastapi import FastAPI, HTTPException, Request, Response
 from typing import Optional
-from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST, make_asgi_app
 
 
-REQUEST_COUNT = Counter('http_requests_total', 'Total HTTP Requests')
+REQUEST_COUNT = Counter('http_requests_total', 'Total HTTP Requests',
+                        ['method', 'endpoint', 'status_code'],)
 app = FastAPI()
+
+metrics_app = make_asgi_app()
+app.mount("/metrics", metrics_app)
+
 
 # уровень логирования, пока что вносится вручную
 logging.basicConfig(
@@ -17,9 +22,28 @@ logging.basicConfig(
 )
 
 
+@app.middleware("http")
+async def monitor_requests(request: Request,
+                           call_next):
+    # Сохраняем информацию о запросе ДО обработки
+    method = request.method
+    endpoint = request.url.path
+    
+    # Выполняем запрос и получаем ответ
+    response = await call_next(request)
+    
+    # Регистрируем метрику ПОСЛЕ получения ответа
+    REQUEST_COUNT.labels(
+        method=method,
+        endpoint=endpoint,
+        status_code=response.status_code
+    ).inc()
+    
+    return response
+
+
 @app.get("/")  # путь апи
 def start_screen(request: Request):
-    REQUEST_COUNT.inc()
     host_ip = request.client.host
     logging.info(f"{host_ip} : Used start screen.")
     raise HTTPException(
@@ -30,7 +54,7 @@ def start_screen(request: Request):
 @app.get("/metrics")
 def metrics(request: Request):
     client_ip = request.client.host
-    if client_ip not in ["127.0.0.1", "::1"]:
+    if client_ip not in ["127.0.0.1", "::1", "172.17.0.1"]:
         raise HTTPException(status_code=403, detail="Access forbidden")
     return Response(
         content=generate_latest(),
@@ -40,7 +64,6 @@ def metrics(request: Request):
 
 @app.get("/api/profile")  # путь апи
 def profile_games(request: Request, id: Optional[int] = None):
-    REQUEST_COUNT.inc()
     host_ip = request.client.host
     if id is None:
         logging.info(f'{host_ip} : Empty "id" variable.')


### PR DESCRIPTION
Переписан метод получения метрик. Добавлены endpoints, status_code.
З.Ы. Нужно для Grafana, чтобы считать не только RPS приложения.